### PR TITLE
refactor(layout): mover lógica de useEffect a ProtectedRoute

### DIFF
--- a/src/Components/ui/layouts/Layout.tsx
+++ b/src/Components/ui/layouts/Layout.tsx
@@ -1,24 +1,13 @@
-import { useEffect, useState } from "react";
-import { Outlet, useNavigate } from "react-router-dom";
-import Cookies from "js-cookie";
-import SideBar from "../SideBar";
+import { useState } from "react";
+import { Outlet } from "react-router-dom";
 import { useViewportGuard } from "@/Hooks/useViewportGuard";
 import ViewportBlocker from "./ViewportBlocker";
+import SideBar from "@/Components/SideBar/SideBar";
 
 export default function Layout() {
-  const navigate = useNavigate();
-
   const isBlocked = useViewportGuard();
-
   const [open, setOpen] = useState(false);
   const environment = import.meta.env.VITE_ENV;
-
-  useEffect(() => {
-    const refreshToken = Cookies.get("token_refresh");
-    if (!refreshToken) {
-      navigate("/");
-    }
-  }, [navigate]);
 
   return (
     <div className="min-h-screen h-full flex flex-col">


### PR DESCRIPTION
Esta PR mueve la lógica de useEffect relacionada con la protección de rutas al componente ProtectedRoute, mejorando la separación de responsabilidades.

Parte 1 de 8 en la serie de refactors.

Base: main → Compare: pr/01-protectedroute